### PR TITLE
Rework git and application processes

### DIFF
--- a/examples/ansible.yaml
+++ b/examples/ansible.yaml
@@ -4,7 +4,7 @@ targets:
   url: http://github.com/redhat-et/fetchit
   methods:
     ansible:
-      targetPath: examples/ansible
+      targetPath: examples/ansible/
       sshDirectory: /root/.ssh
       schedule: "*/1 * * * *"
   branch: main

--- a/examples/ci-config.yaml
+++ b/examples/ci-config.yaml
@@ -4,6 +4,6 @@ targets:
   url: http://github.com/redhat-et/fetchit
   methods:
     raw:
-      targetPath: examples/raw
+      targetPath: examples/raw/
       schedule: "*/1 * * * *"
   branch: ci

--- a/examples/ci-filetransfer-config.yaml
+++ b/examples/ci-filetransfer-config.yaml
@@ -4,7 +4,7 @@ targets:
   url: http://github.com/redhat-et/fetchit
   methods:
     fileTransfer:
-      targetPath: examples/filetransfer
+      targetPath: examples/filetransfer/
       destinationDirectory: /tmp/ft
       schedule: "*/1 * * * *"
   branch: ci

--- a/examples/config-reload-with-skew.yaml
+++ b/examples/config-reload-with-skew.yaml
@@ -7,10 +7,10 @@ targets:
   url: https://github.com/redhat-et/fetchit
   methods:
     configTarget:
-      configUrl: https://raw.githubusercontent.com/redhat-et/fetchit/main/examples/config-reload-with-skew.yaml
+      configUrl: https://raw.githubusercontent.com/josephsawaya/fetchit/better-apply/examples/config-reload-with-skew.yaml
       schedule: "*/2 * * * *"
     raw:
-      targetPath: examples/raw
+      targetPath: examples/raw/
       schedule: "*/1 * * * *"
       pullImage: true
       skew: 5000

--- a/examples/config-reload.yaml
+++ b/examples/config-reload.yaml
@@ -7,10 +7,10 @@ targets:
   url: https://github.com/redhat-et/fetchit
   methods:
     configTarget:
-      configUrl: https://raw.githubusercontent.com/redhat-et/fetchit/main/examples/config-reload.yaml
+      configUrl: https://raw.githubusercontent.com/josephsawaya/fetchit/better-apply/examples/config-reload.yaml
       schedule: "*/2 * * * *"
     raw:
-      targetPath: examples/raw
+      targetPath: examples/raw/
       schedule: "*/1 * * * *"
       pullImage: true
   branch: main

--- a/examples/config-url-with-skew.yaml
+++ b/examples/config-url-with-skew.yaml
@@ -5,6 +5,6 @@ targets:
   url: http://github.com/redhat-et/fetchit
   methods:
     configTarget:
-      configUrl: https://raw.githubusercontent.com/redhat-et/fetchit/main/examples/config-reload-with-skew.yaml
+      configUrl: https://raw.githubusercontent.com/josephsawaya/fetchit/better-apply/examples/config-reload-with-skew.yaml
       schedule: "*/1 * * * *"
 

--- a/examples/config-url.yaml
+++ b/examples/config-url.yaml
@@ -5,6 +5,6 @@ targets:
   url: http://github.com/redhat-et/fetchit
   methods:
     configTarget:
-      configUrl: https://raw.githubusercontent.com/redhat-et/fetchit/main/examples/config-reload.yaml
+      configUrl: https://raw.githubusercontent.com/josephsawaya/fetchit/better-apply/examples/config-reload.yaml
       schedule: "*/1 * * * *"
 

--- a/examples/default-volume.yaml
+++ b/examples/default-volume.yaml
@@ -3,6 +3,6 @@ targets:
   url: http://github.com/redhat-et/fetchit
   methods:
     raw:
-      targetPath: examples/raw
+      targetPath: examples/raw/
       schedule: "*/1 * * * *"
   branch: main

--- a/examples/filetransfer-config.yaml
+++ b/examples/filetransfer-config.yaml
@@ -4,7 +4,7 @@ targets:
   url: http://github.com/redhat-et/fetchit
   methods:
     filetransfer:
-      targetPath: examples/filetransfer
+      targetPath: examples/filetransfer/
       destinationDirectory: /tmp/ft
       schedule: "*/1 * * * *"
   branch: main

--- a/examples/full-suite-with-skew.yaml
+++ b/examples/full-suite-with-skew.yaml
@@ -4,7 +4,7 @@ targets:
   url: http://github.com/redhat-et/fetchit
   methods:
     raw:
-      targetPath: examples/raw
+      targetPath: examples/raw/
       schedule: "*/1 * * * *"
       skew: 10000
     systemd:
@@ -14,11 +14,11 @@ targets:
       schedule: "*/1 * * * *"
       skew: 1000
     ansible:
-      targetPath: examples/ansible
+      targetPath: examples/ansible/
       sshDirectory: /root/.ssh
       schedule: "*/1 * * * *"
     filetransfer:
-      targetPath: examples/filetransfer
+      targetPath: examples/filetransfer/
       destinationDirectory: /tmp/ft
       schedule: "*/1 * * * *"
       skew: 3000

--- a/examples/full-suite.yaml
+++ b/examples/full-suite.yaml
@@ -4,7 +4,7 @@ targets:
   url: http://github.com/redhat-et/fetchit
   methods:
     raw:
-      targetPath: examples/raw
+      targetPath: examples/raw/
       schedule: "*/1 * * * *"
     systemd:
       targetPath: examples/systemd/httpd.service
@@ -12,11 +12,11 @@ targets:
       enable: false
       schedule: "*/1 * * * *"
     ansible:
-      targetPath: examples/ansible
+      targetPath: examples/ansible/
       sshDirectory: /root/.ssh
       schedule: "*/1 * * * *"
     filetransfer:
-      targetPath: examples/filetransfer
+      targetPath: examples/filetransfer/
       destinationDirectory: /tmp/ft
       schedule: "*/1 * * * *"
     clean:

--- a/examples/kube-play-config.yaml
+++ b/examples/kube-play-config.yaml
@@ -4,6 +4,6 @@ targets:
   url: http://github.com/redhat-et/fetchit
   methods:
     kube:
-      targetPath: examples/kube
+      targetPath: examples/kube/
       schedule: "*/1 * * * *"
   branch: main

--- a/examples/raw-config.yaml
+++ b/examples/raw-config.yaml
@@ -4,7 +4,7 @@ targets:
   url: https://github.com/redhat-et/fetchit
   methods:
     raw:
-      targetPath: examples/raw
+      targetPath: examples/raw/
       schedule: "*/1 * * * *"
       pullImage: true
   branch: main

--- a/examples/readme-config.yaml
+++ b/examples/readme-config.yaml
@@ -8,5 +8,5 @@ targets:
       destinationDirectory: /tmp
       schedule: "*/1 * * * *"
     raw:
-      targetPath: examples/raw
+      targetPath: examples/raw/
       schedule: "*/1 * * * *"

--- a/pkg/engine/apply.go
+++ b/pkg/engine/apply.go
@@ -1,0 +1,215 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/redhat-et/fetchit/pkg/engine/utils"
+)
+
+/*
+For any given target, will get the head of the branch
+in the repository specified by the target's url
+*/
+func (fc *FetchitConfig) GetLatest(target *Target) (plumbing.Hash, error) {
+	directory := filepath.Base(target.Url)
+
+	repo, err := git.PlainOpen(directory)
+	if err != nil {
+		return plumbing.Hash{}, utils.WrapErr(err, "Error opening repository: %s", directory)
+	}
+
+	refSpec := config.RefSpec(fmt.Sprintf("+refs/heads/%s:refs/heads/%s", target.Branch, target.Branch))
+	if err = repo.Fetch(&git.FetchOptions{
+		RefSpecs: []config.RefSpec{refSpec, "HEAD:refs/heads/HEAD"},
+		Force:    true,
+	}); err != nil && err != git.NoErrAlreadyUpToDate {
+		return plumbing.Hash{}, utils.WrapErr(err, "Error fetching branch %s from remote repository %s", target.Branch, target.Url)
+	}
+
+	branch, err := repo.Reference(plumbing.ReferenceName(fmt.Sprintf("refs/heads/%s", target.Branch)), false)
+	if err != nil {
+		return plumbing.Hash{}, utils.WrapErr(err, "Error getting reference to branch %s", target.Branch)
+	}
+
+	wt, err := repo.Worktree()
+	if err != nil {
+		return plumbing.Hash{}, utils.WrapErr(err, "Error getting reference to worktree for repository", target.Name)
+	}
+
+	err = wt.Checkout(&git.CheckoutOptions{Hash: branch.Hash()})
+	if err != nil {
+		return plumbing.Hash{}, utils.WrapErr(err, "Error checking out %s on branch %s", branch.Hash(), target.Branch)
+	}
+
+	return branch.Hash(), err
+}
+
+func (fc *FetchitConfig) GetCurrent(target *Target, method string) (plumbing.Hash, error) {
+	directory := filepath.Base(target.Url)
+	tagName := fmt.Sprintf("current-%s", method)
+
+	repo, err := git.PlainOpen(directory)
+	if err != nil {
+		return plumbing.Hash{}, utils.WrapErr(err, "Error opening repository: %s", directory)
+	}
+
+	ref, err := repo.Tag(tagName)
+	if err == git.ErrTagNotFound {
+		return plumbing.Hash{}, nil
+	} else if err != nil {
+		return plumbing.Hash{}, utils.WrapErr(err, "Error getting reference to current tag")
+	}
+
+	return ref.Hash(), err
+}
+
+func (fc *FetchitConfig) UpdateCurrent(ctx context.Context, target *Target, method string, newCurrent plumbing.Hash) error {
+	directory := filepath.Base(target.Url)
+	tagName := fmt.Sprintf("current-%s", method)
+
+	repo, err := git.PlainOpen(directory)
+	if err != nil {
+		return utils.WrapErr(err, "Error opening repository: %s", directory)
+	}
+
+	err = repo.DeleteTag(tagName)
+	if err != nil && err != git.ErrTagNotFound {
+		return utils.WrapErr(err, "Error deleting old current tag")
+	}
+
+	_, err = repo.CreateTag(tagName, newCurrent, nil)
+	if err != nil {
+		return utils.WrapErr(err, "Error creating new current tag with hash %s", newCurrent)
+	}
+
+	return nil
+}
+
+// Side effects are running/applying changes concurrently and on success moving old "current" tag
+func (fc *FetchitConfig) Apply(
+	ctx context.Context,
+	mo *SingleMethodObj,
+	currentState plumbing.Hash,
+	desiredState plumbing.Hash,
+	targetPath string,
+	tags *[]string,
+) error {
+	if desiredState.IsZero() {
+		return errors.New("Cannot run Apply if desired state is empty")
+	}
+	directory := filepath.Base(mo.Target.Url)
+
+	currentTree, err := getTreeFromHash(directory, currentState)
+	if err != nil {
+		return utils.WrapErr(err, "Error getting tree from hash %s", currentState)
+	}
+
+	desiredTree, err := getTreeFromHash(directory, desiredState)
+	if err != nil {
+		return utils.WrapErr(err, "Error getting tree from hash %s", desiredState)
+	}
+
+	changeMap, err := getFilteredChangeMap(directory, targetPath, currentTree, desiredTree, tags)
+	if err != nil {
+		return utils.WrapErr(err, "Error getting filtered change map from %s to %s", currentState, desiredState)
+	}
+
+	err = fc.runChangesConcurrent(ctx, mo, changeMap)
+	if err != nil {
+		return utils.WrapErr(err, "Error applying change from %s to %s for path %s in %s",
+			currentState, desiredState, targetPath, directory,
+		)
+	}
+
+	return nil
+}
+
+func getTreeFromHash(directory string, hash plumbing.Hash) (*object.Tree, error) {
+	if hash.IsZero() {
+		return &object.Tree{}, nil
+	}
+
+	repo, err := git.PlainOpen(directory)
+	if err != nil {
+		return nil, utils.WrapErr(err, "Error opening repository: %s", directory)
+	}
+
+	commit, err := repo.CommitObject(hash)
+	if err != nil {
+		return nil, utils.WrapErr(err, "Error getting commit at hash %s from repo %s", hash, directory)
+	}
+
+	tree, err := commit.Tree()
+	if err != nil {
+		return nil, utils.WrapErr(err, "Error getting tree from commit at hash %s from repo %s", hash, directory)
+	}
+
+	return tree, nil
+}
+
+func getFilteredChangeMap(
+	directory string,
+	targetPath string,
+	currentTree,
+	desiredTree *object.Tree,
+	tags *[]string,
+) (map[*object.Change]string, error) {
+
+	changes, err := currentTree.Diff(desiredTree)
+	if err != nil {
+		return nil, utils.WrapErr(err, "Error getting diff between current and latest", targetPath)
+	}
+
+	changeMap := make(map[*object.Change]string)
+	for _, change := range changes {
+		if strings.Contains(change.To.Name, targetPath) {
+			checkTag(tags, change.To.Name)
+			path := filepath.Join(directory, change.To.Name)
+			changeMap[change] = path
+		} else if strings.Contains(change.From.Name, targetPath) {
+			checkTag(tags, change.From.Name)
+			changeMap[change] = deleteFile
+		}
+	}
+
+	return changeMap, nil
+}
+
+func checkTag(tags *[]string, name string) bool {
+	if tags == nil {
+		return true
+	}
+	for _, suffix := range *tags {
+		if strings.HasSuffix(name, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func (fc *FetchitConfig) runChangesConcurrent(ctx context.Context, mo *SingleMethodObj, changeMap map[*object.Change]string) error {
+	ch := make(chan error)
+	for change, changePath := range changeMap {
+		go func(ch chan<- error, changePath string, change *object.Change) {
+			if err := fc.EngineMethod(ctx, mo, changePath, change); err != nil {
+				ch <- utils.WrapErr(err, "error running engine method for change from: %s to %s", change.From.Name, change.To.Name)
+			}
+			ch <- nil
+		}(ch, changePath, change)
+	}
+	for range changeMap {
+		err := <-ch
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/engine/helpers.go
+++ b/pkg/engine/helpers.go
@@ -8,9 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strings"
 
-	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/object"
 
 	"k8s.io/klog/v2"
@@ -71,12 +69,12 @@ func downloadUpdateConfigFile(urlStr string, existsAlready, initial bool) (bool,
 
 func getChangeString(change *object.Change) (*string, error) {
 	if change != nil {
-		_, to, err := change.Files()
+		from, _, err := change.Files()
 		if err != nil {
 			return nil, err
 		}
-		if to != nil {
-			s, err := to.Contents()
+		if from != nil {
+			s, err := from.Contents()
 			if err != nil {
 				return nil, err
 			}
@@ -84,44 +82,4 @@ func getChangeString(change *object.Change) (*string, error) {
 		}
 	}
 	return nil, nil
-}
-
-func checkTag(tags *[]string, name string) bool {
-	if tags == nil {
-		return true
-	}
-	for _, tag := range *tags {
-		if strings.HasSuffix(name, tag) {
-			return true
-		}
-	}
-	return false
-}
-
-func getTree(r *git.Repository, oldCommit *object.Commit) (*object.Tree, *object.Commit, error) {
-	if oldCommit != nil {
-		// ... retrieve the tree from the commit
-		tree, err := oldCommit.Tree()
-		if err != nil {
-			return nil, nil, fmt.Errorf("error when retrieving tree: %s", err)
-		}
-		return tree, nil, nil
-	}
-	var newCommit *object.Commit
-	ref, err := r.Head()
-	if err != nil {
-		return nil, nil, fmt.Errorf("error when retrieving head: %s", err)
-	}
-	// ... retrieving the commit object
-	newCommit, err = r.CommitObject(ref.Hash())
-	if err != nil {
-		return nil, nil, fmt.Errorf("error when retrieving commit: %s", err)
-	}
-
-	// ... retrieve the tree from the commit
-	tree, err := newCommit.Tree()
-	if err != nil {
-		return nil, nil, fmt.Errorf("error when retrieving tree: %s", err)
-	}
-	return tree, newCommit, nil
 }


### PR DESCRIPTION
This commit reworks the way fetchit gets changes
and applies them.

The point of this commit is to simplify the fetchit
process in order to make it more clear and extensible.

This commit reduces the previous process for applying
the initial state and following changes to just getting
the current state, getting the latest state, then applying
a method to the difference of those two states. In the case
of an initial apply, the current state is empty. Otherwise
the current state is marked by a git tag on the commit
corresponding to the current state.

This commit also fixes a bug where the scheduler was only
scheduling the first method in the queue to run immediately
rather than all of them.

This commit also removes all calls to the update method
of the fetchit config, since fetchit is using pointers to
manipulate target objects instead of making copies of them.

Signed-off-by: Joseph Sawaya <jsawaya@redhat.com>