### PR TITLE
Update examples with trailing slashes

### DIFF
--- a/examples/ansible.yaml
+++ b/examples/ansible.yaml
@@ -4,7 +4,7 @@ targets:
   url: http://github.com/redhat-et/fetchit
   methods:
     ansible:
-      targetPath: examples/ansible
+      targetPath: examples/ansible/
       sshDirectory: /root/.ssh
       schedule: "*/1 * * * *"
   branch: main

--- a/examples/ci-config.yaml
+++ b/examples/ci-config.yaml
@@ -4,6 +4,6 @@ targets:
   url: http://github.com/redhat-et/fetchit
   methods:
     raw:
-      targetPath: examples/raw
+      targetPath: examples/raw/
       schedule: "*/1 * * * *"
   branch: ci

--- a/examples/ci-filetransfer-config.yaml
+++ b/examples/ci-filetransfer-config.yaml
@@ -4,7 +4,7 @@ targets:
   url: http://github.com/redhat-et/fetchit
   methods:
     fileTransfer:
-      targetPath: examples/filetransfer
+      targetPath: examples/filetransfer/
       destinationDirectory: /tmp/ft
       schedule: "*/1 * * * *"
   branch: ci

--- a/examples/config-reload-with-skew.yaml
+++ b/examples/config-reload-with-skew.yaml
@@ -10,7 +10,7 @@ targets:
       configUrl: https://raw.githubusercontent.com/redhat-et/fetchit/main/examples/config-reload-with-skew.yaml
       schedule: "*/2 * * * *"
     raw:
-      targetPath: examples/raw
+      targetPath: examples/raw/
       schedule: "*/1 * * * *"
       pullImage: true
       skew: 5000

--- a/examples/config-reload.yaml
+++ b/examples/config-reload.yaml
@@ -10,7 +10,7 @@ targets:
       configUrl: https://raw.githubusercontent.com/redhat-et/fetchit/main/examples/config-reload.yaml
       schedule: "*/2 * * * *"
     raw:
-      targetPath: examples/raw
+      targetPath: examples/raw/
       schedule: "*/1 * * * *"
       pullImage: true
   branch: main

--- a/examples/default-volume.yaml
+++ b/examples/default-volume.yaml
@@ -3,6 +3,6 @@ targets:
   url: http://github.com/redhat-et/fetchit
   methods:
     raw:
-      targetPath: examples/raw
+      targetPath: examples/raw/
       schedule: "*/1 * * * *"
   branch: main

--- a/examples/filetransfer-config.yaml
+++ b/examples/filetransfer-config.yaml
@@ -4,7 +4,7 @@ targets:
   url: http://github.com/redhat-et/fetchit
   methods:
     filetransfer:
-      targetPath: examples/filetransfer
+      targetPath: examples/filetransfer/
       destinationDirectory: /tmp/ft
       schedule: "*/1 * * * *"
   branch: main

--- a/examples/full-suite-with-skew.yaml
+++ b/examples/full-suite-with-skew.yaml
@@ -4,7 +4,7 @@ targets:
   url: http://github.com/redhat-et/fetchit
   methods:
     raw:
-      targetPath: examples/raw
+      targetPath: examples/raw/
       schedule: "*/1 * * * *"
       skew: 10000
     systemd:
@@ -14,11 +14,11 @@ targets:
       schedule: "*/1 * * * *"
       skew: 1000
     ansible:
-      targetPath: examples/ansible
+      targetPath: examples/ansible/
       sshDirectory: /root/.ssh
       schedule: "*/1 * * * *"
     filetransfer:
-      targetPath: examples/filetransfer
+      targetPath: examples/filetransfer/
       destinationDirectory: /tmp/ft
       schedule: "*/1 * * * *"
       skew: 3000

--- a/examples/full-suite.yaml
+++ b/examples/full-suite.yaml
@@ -4,7 +4,7 @@ targets:
   url: http://github.com/redhat-et/fetchit
   methods:
     raw:
-      targetPath: examples/raw
+      targetPath: examples/raw/
       schedule: "*/1 * * * *"
     systemd:
       targetPath: examples/systemd/httpd.service
@@ -12,11 +12,11 @@ targets:
       enable: false
       schedule: "*/1 * * * *"
     ansible:
-      targetPath: examples/ansible
+      targetPath: examples/ansible/
       sshDirectory: /root/.ssh
       schedule: "*/1 * * * *"
     filetransfer:
-      targetPath: examples/filetransfer
+      targetPath: examples/filetransfer/
       destinationDirectory: /tmp/ft
       schedule: "*/1 * * * *"
     clean:

--- a/examples/kube-play-config.yaml
+++ b/examples/kube-play-config.yaml
@@ -4,6 +4,6 @@ targets:
   url: http://github.com/redhat-et/fetchit
   methods:
     kube:
-      targetPath: examples/kube
+      targetPath: examples/kube/
       schedule: "*/1 * * * *"
   branch: main

--- a/examples/raw-config.yaml
+++ b/examples/raw-config.yaml
@@ -4,7 +4,7 @@ targets:
   url: https://github.com/redhat-et/fetchit
   methods:
     raw:
-      targetPath: examples/raw
+      targetPath: examples/raw/
       schedule: "*/1 * * * *"
       pullImage: true
   branch: main

--- a/examples/readme-config.yaml
+++ b/examples/readme-config.yaml
@@ -8,5 +8,5 @@ targets:
       destinationDirectory: /tmp
       schedule: "*/1 * * * *"
     raw:
-      targetPath: examples/raw
+      targetPath: examples/raw/
       schedule: "*/1 * * * *"


### PR DESCRIPTION
This commit adds trailing slashes to all target paths
specifying direcotries, in the configs in the examples
directory.

Signed-off-by: Joseph Sawaya <jsawaya@redhat.com>