### PR TITLE
Separate git-specific methods from non-git

### DIFF
--- a/docs/methods.rst
+++ b/docs/methods.rst
@@ -4,7 +4,7 @@ The YAML configuration file defines git targets and the method to use, how frequ
 and various configuration values that relate to that method.
 
 A target is a unique value that holds methods. Mutiple git targets (targetConfigs) can be defined. Methods that can be configured
-include `Raw`, `Systemd`, `Kube`, `Ansible`, `FileTransfer`, `Clean`, and `FetchitConfigFile`.
+include `Raw`, `Systemd`, `Kube`, `Ansible`, `FileTransfer`, `Prune`, and `ConfigReload`.
 
 Dynamic Configuration Reload
 =============
@@ -89,12 +89,21 @@ A Raw JSON file can contain the following fields.
 Volume and host mounts can be provided in the JSON file.
 
 
+PodmanAutoUpdate
+-------
+If this method is present in the config file, podman-auto-update.service & podman-auto-update.timer
+will be enabled on the host. Podman auto-update will look for image updates with all podman-generated unit files
+that include the auto-update label, according to the timer schedule. Can configure for root, non-root, or both.
+
+.. code-block:: yaml
+
+   podmanAutoUpdate:
+     root: true
+     user: true
+
 Systemd
 -------
 SystemdTarget is a method that will place, enable, and restart systemd unit files.
-SystemdTarget can also enable podman-auto-update.service & podman-auto-update.timer on the host.
-With AutoUpdateAll: True, all other fields are ignored. This is because podman auto-update will
-look for image updates with all podman-generated unit files that include the auto-update label.
 
 .. code-block:: yaml
 
@@ -108,14 +117,6 @@ look for image updates with all podman-generated unit files that include the aut
        enable: true
        schedule: "*/5 * * * *"
      branch: main
-
-.. code-block:: yaml
-
-   targetConfigs:
-   - name: autoupdate
-     systemd:
-       name: autoupdate-ex
-       autoUpdateAll: true
 
 File Transfer
 -------------

--- a/examples/clean-config.yaml
+++ b/examples/clean-config.yaml
@@ -1,8 +1,4 @@
-targetConfigs:
-- name: fetchit
-  url: http://github.com/containers/fetchit
-  clean:
-    All: true
-    Volumes: true
-    schedule: "*/1 * * * *"
-  branch: main
+prune:
+  All: true
+  Volumes: true
+  schedule: "*/1 * * * *"

--- a/examples/full-suite.yaml
+++ b/examples/full-suite.yaml
@@ -1,3 +1,7 @@
+prune:
+  All: true
+  Volumes: false
+  schedule: "*/1 * * * *"
 targetConfigs:
 - name: fetchit
   url: http://github.com/containers/fetchit
@@ -21,9 +25,5 @@ targetConfigs:
   - name: ft-ex
     targetPath: examples/filetransfer/
     destinationDirectory: /tmp/ft
-    schedule: "*/1 * * * *"
-  clean:
-    All: true
-    Volumes: false
     schedule: "*/1 * * * *"
   branch: main

--- a/examples/imageLoad-config.yaml
+++ b/examples/imageLoad-config.yaml
@@ -1,13 +1,13 @@
-targetConfigs:
-- name: fetchit
-  url: https://github.com/cooktheryan/fetchit
-  image:
+images:
   - name: httpd-ex
     url: http://localhost:8080/httpd.tar
     schedule: "*/1 * * * *"
+targetConfigs:
+- name: fetchit
+  url: https://github.com/containers/fetchit
   raw:
   - name: raw-ex
     targetPath: examples/imageLoad/
     schedule: "*/1 * * * *"
     pullImage: false
-  branch: imageWNewMeth
+  branch: main

--- a/examples/systemd-autoupdate.yaml
+++ b/examples/systemd-autoupdate.yaml
@@ -1,8 +1,6 @@
+podmanAutoUpdate:
+  root: true
 targetConfigs:
-- name: autoupdate
-  systemd:
-  - name: autoupdate-ex
-    autoUpdateAll: true
 - name: fetchit
   url: http://github.com/containers/fetchit
   systemd:

--- a/pkg/engine/ansible.go
+++ b/pkg/engine/ansible.go
@@ -36,7 +36,7 @@ func (ans *Ansible) Process(ctx, conn context.Context, PAT string, skew int) {
 	if ans.initialRun {
 		err := getClone(target, PAT)
 		if err != nil {
-			klog.Errorf("Failed to clone repo at %s for target %s: %v", target.url, target.Name, err)
+			klog.Errorf("Failed to clone repo at %s for target %s: %v", target.url, target.name, err)
 			return
 		}
 

--- a/pkg/engine/apply.go
+++ b/pkg/engine/apply.go
@@ -62,7 +62,7 @@ func getLatest(target *Target) (plumbing.Hash, error) {
 
 	wt, err := repo.Worktree()
 	if err != nil {
-		return plumbing.Hash{}, utils.WrapErr(err, "Error getting reference to worktree for repository", target.Name)
+		return plumbing.Hash{}, utils.WrapErr(err, "Error getting reference to worktree for repository", target.name)
 	}
 
 	err = wt.Checkout(&git.CheckoutOptions{Hash: branch.Hash()})

--- a/pkg/engine/common.go
+++ b/pkg/engine/common.go
@@ -56,7 +56,7 @@ func zeroToCurrent(ctx, conn context.Context, m Method, target *Target, tag *[]s
 			return fmt.Errorf("Failed to apply changes: %v", err)
 		}
 
-		klog.Infof("Moved %s to %s for target %s", m.GetName(), current, target.Name)
+		klog.Infof("Moved %s to %s for target %s", m.GetName(), current, target.name)
 	}
 
 	return nil
@@ -80,9 +80,9 @@ func currentToLatest(ctx, conn context.Context, m Method, target *Target, tag *[
 		}
 
 		updateCurrent(ctx, target, latest, m.GetKind(), m.GetName())
-		klog.Infof("Moved %s from %s to %s for target %s", m.GetName(), current, latest, target.Name)
+		klog.Infof("Moved %s from %s to %s for target %s", m.GetName(), current, latest, target.name)
 	} else {
-		klog.Infof("No changes applied to target %s this run, %s currently at %s", target.Name, m.GetKind(), current)
+		klog.Infof("No changes applied to target %s this run, %s currently at %s", target.name, m.GetKind(), current)
 	}
 
 	return nil

--- a/pkg/engine/config.go
+++ b/pkg/engine/config.go
@@ -37,12 +37,6 @@ func (c *ConfigReload) GetName() string {
 	return configFileMethod
 }
 
-func (c *ConfigReload) GetTarget() *Target {
-	return &Target{
-		Name: configFileMethod,
-	}
-}
-
 func (c *ConfigReload) Process(ctx, conn context.Context, PAT string, skew int) {
 	time.Sleep(time.Duration(skew) * time.Millisecond)
 	// configURL in config file will override the environment variable

--- a/pkg/engine/filetransfer.go
+++ b/pkg/engine/filetransfer.go
@@ -32,7 +32,7 @@ func (ft *FileTransfer) Process(ctx, conn context.Context, PAT string, skew int)
 	if ft.initialRun {
 		err := getClone(target, PAT)
 		if err != nil {
-			klog.Errorf("Failed to clone repo at %s for target %s: %v", target.url, target.Name, err)
+			klog.Errorf("Failed to clone repo at %s for target %s: %v", target.url, target.name, err)
 			return
 		}
 

--- a/pkg/engine/image.go
+++ b/pkg/engine/image.go
@@ -32,7 +32,7 @@ func (i *Image) Process(ctx, conn context.Context, PAT string, skew int) {
 
 	err := i.loadPodman(ctx, conn, i.Url)
 	if err != nil {
-		klog.Warningf("Repo: %s Method: %s encountered error: %v, resetting...", target.Name, imageMethod, err)
+		klog.Warningf("Repo: %s Method: %s encountered error: %v, resetting...", target.name, imageMethod, err)
 	}
 
 }

--- a/pkg/engine/kube.go
+++ b/pkg/engine/kube.go
@@ -47,7 +47,7 @@ func (k *Kube) Process(ctx, conn context.Context, PAT string, skew int) {
 	if initial {
 		err := getClone(target, PAT)
 		if err != nil {
-			klog.Errorf("Failed to clone repo at %s for target %s: %v", target.url, target.Name, err)
+			klog.Errorf("Failed to clone repo at %s for target %s: %v", target.url, target.name, err)
 			return
 		}
 

--- a/pkg/engine/raw.go
+++ b/pkg/engine/raw.go
@@ -90,7 +90,7 @@ func (r *Raw) Process(ctx context.Context, conn context.Context, PAT string, ske
 	if r.initialRun {
 		err := getClone(target, PAT)
 		if err != nil {
-			klog.Errorf("Failed to clone repo at %s for target %s: %v", target.url, target.Name, err)
+			klog.Errorf("Failed to clone repo at %s for target %s: %v", target.url, target.name, err)
 			return
 		}
 

--- a/pkg/engine/types.go
+++ b/pkg/engine/types.go
@@ -20,35 +20,37 @@ type Method interface {
 
 // FetchitConfig requires necessary objects to process targets
 type FetchitConfig struct {
-	TargetConfigs []*TargetConfig `mapstructure:"targetConfigs"`
-	ConfigReload  *ConfigReload   `mapstructure:"configReload"`
-	PAT           string          `mapstructure:"pat"`
-	conn          context.Context
-	scheduler     *gocron.Scheduler
+	TargetConfigs    []*TargetConfig   `mapstructure:"targetConfigs"`
+	ConfigReload     *ConfigReload     `mapstructure:"configReload"`
+	Prune            *Prune            `mapstructure:"prune"`
+	PodmanAutoUpdate *PodmanAutoUpdate `mapstructure:"podmanAutoUpdate"`
+	Images           []*Image          `mapstructure:"images"`
+	PAT              string            `mapstructure:"pat"`
+	conn             context.Context
+	scheduler        *gocron.Scheduler
 }
 
 type TargetConfig struct {
 	Name         string          `mapstructure:"name"`
 	Url          string          `mapstructure:"url"`
 	Branch       string          `mapstructure:"branch"`
-	Clean        *Clean          `mapstructure:"clean"`
 	Ansible      []*Ansible      `mapstructure:"ansible"`
 	FileTransfer []*FileTransfer `mapstructure:"filetransfer"`
 	Kube         []*Kube         `mapstructure:"kube"`
 	Raw          []*Raw          `mapstructure:"raw"`
 	Systemd      []*Systemd      `mapstructure:"systemd"`
-	Image        []*Image        `mapstructure:"image"`
 
+	image        *Image
+	prune        *Prune
 	configReload *ConfigReload
 	mu           sync.Mutex
 }
 
 type Target struct {
-	Name         string
-	url          string
-	branch       string
-	configReload *ConfigReload
-	mu           sync.Mutex
+	name   string
+	url    string
+	branch string
+	mu     sync.Mutex
 }
 
 type SchedInfo struct {


### PR DESCRIPTION
This PR introduces PodmanAutoUpdate and renames Clean -> Prune. Also, moves PodmanAutoUpdate, Prune, & Image out of TargetConfig. These will be top-level in the config file now, like ConfigReload is.
