### PR TITLE
fix repo open and clarify PlainOpen errors

### DIFF
--- a/examples/ansible.yaml
+++ b/examples/ansible.yaml
@@ -1,6 +1,5 @@
 targetConfigs:
-- name: fetchit
-  url: http://github.com/containers/fetchit
+- url: http://github.com/containers/fetchit
   ansible:
     - name: ansible
       targetPath: examples/ansible

--- a/examples/ci-config.yaml
+++ b/examples/ci-config.yaml
@@ -1,6 +1,5 @@
 targetConfigs:
-- name: fetchit
-  url: http://github.com/containers/fetchit
+- url: http://github.com/containers/fetchit
   raw:
   - name: raw
     targetPath: examples/raw

--- a/examples/ci-filetransfer-config.yaml
+++ b/examples/ci-filetransfer-config.yaml
@@ -1,6 +1,5 @@
 targetConfigs:
-- name: fetchit
-  url: http://github.com/containers/fetchit
+- url: http://github.com/containers/fetchit
   filetransfer:
   - name: ft-example
     targetPath: examples/filetransfer

--- a/examples/config-reload.yaml
+++ b/examples/config-reload.yaml
@@ -6,8 +6,7 @@ configReload:
   configURL: https://raw.githubusercontent.com/containers/fetchit/main/examples/config-reload.yaml
   schedule: "*/2 * * * *"
 targetConfigs:
-- name: fetchit
-  url: https://github.com/containers/fetchit
+- url: https://github.com/containers/fetchit
   raw:
   - name: raw-ex
     targetPath: examples/raw

--- a/examples/filetransfer-config-single-file.yaml
+++ b/examples/filetransfer-config-single-file.yaml
@@ -1,6 +1,5 @@
 targetConfigs:
-- name: fetchit
-  url: http://github.com/containers/fetchit
+- url: http://github.com/containers/fetchit
   filetransfer:
   - name: ft-ex
     targetPath: examples/filetransfer

--- a/examples/filetransfer-config.yaml
+++ b/examples/filetransfer-config.yaml
@@ -1,6 +1,5 @@
 targetConfigs:
-- name: fetchit
-  url: http://github.com/containers/fetchit
+- url: http://github.com/containers/fetchit
   filetransfer:
   - name: ft-ex
     targetPath: examples/filetransfer

--- a/examples/full-suite-disconnected-usb.yaml
+++ b/examples/full-suite-disconnected-usb.yaml
@@ -1,6 +1,5 @@
 targetConfigs:
-- name: fetchit
-  disconnected: true
+- disconnected: true
   device: /dev/sda1
   raw:
   - name: raw-ex

--- a/examples/full-suite-disconnected.yaml
+++ b/examples/full-suite-disconnected.yaml
@@ -1,6 +1,5 @@
 targetConfigs:
-- name: fetchit
-  disconnected: true
+- disconnected: true
   url: http://localhost:9000/fetchit.zip
   raw:
   - name: raw-ex

--- a/examples/full-suite-with-skew.yaml
+++ b/examples/full-suite-with-skew.yaml
@@ -1,6 +1,5 @@
 targetConfigs:
-- name: fetchit
-  url: http://github.com/containers/fetchit
+- url: http://github.com/containers/fetchit
   raw:
   - name: raw-ex
     targetPath: examples/raw

--- a/examples/full-suite.yaml
+++ b/examples/full-suite.yaml
@@ -3,8 +3,7 @@ prune:
   Volumes: false
   schedule: "*/1 * * * *"
 targetConfigs:
-- name: fetchit
-  url: http://github.com/containers/fetchit
+- url: http://github.com/containers/fetchit
   raw:
   - name: raw-ex
     targetPath: examples/raw

--- a/examples/glob-config.yaml
+++ b/examples/glob-config.yaml
@@ -1,6 +1,5 @@
 targetConfigs:
-- name: fetchit
-  url: https://github.com/josephsawaya/fetchit
+- url: https://github.com/josephsawaya/fetchit
   raw:
   - name: raw-ex
     targetPath: examples/raw

--- a/examples/imageLoad-config.yaml
+++ b/examples/imageLoad-config.yaml
@@ -3,8 +3,7 @@ images:
     url: http://localhost:8080/httpd.tar
     schedule: "*/1 * * * *"
 targetConfigs:
-- name: fetchit
-  url: https://github.com/containers/fetchit
+- url: https://github.com/containers/fetchit
   raw:
   - name: raw-ex
     targetPath: examples/imageLoad

--- a/examples/kube-play-config.yaml
+++ b/examples/kube-play-config.yaml
@@ -1,6 +1,5 @@
 targetConfigs:
-- name: fetchit
-  url: http://github.com/containers/fetchit
+- url: http://github.com/containers/fetchit
   kube:
   - name: kube-ex
     targetPath: examples/kube

--- a/examples/raw-config.yaml
+++ b/examples/raw-config.yaml
@@ -1,6 +1,5 @@
 targetConfigs:
-- name: fetchit
-  url: https://github.com/containers/fetchit
+- url: https://github.com/containers/fetchit
   raw:
   - name: raw-ex
     targetPath: examples/raw

--- a/examples/readme-config.yaml
+++ b/examples/readme-config.yaml
@@ -1,6 +1,5 @@
 targetConfigs:
-- name: fetchit
-  url: http://github.com/containers/fetchit
+- url: http://github.com/containers/fetchit
   branch: main
   filetransfer:
   - name: ft-ex

--- a/examples/systemd-autoupdate.yaml
+++ b/examples/systemd-autoupdate.yaml
@@ -1,8 +1,7 @@
 podmanAutoUpdate:
   root: true
 targetConfigs:
-- name: fetchit
-  url: http://github.com/containers/fetchit
+- url: http://github.com/containers/fetchit
   systemd:
   - name: sysd-ex
     targetPath: examples/systemd

--- a/examples/systemd-config-single-file.yaml
+++ b/examples/systemd-config-single-file.yaml
@@ -1,6 +1,5 @@
 targetConfigs:
-- name: fetchit
-  url: http://github.com/containers/fetchit
+- url: http://github.com/containers/fetchit
   systemd:
   - name: sysd-ex
     targetPath: examples/systemd

--- a/examples/systemd-config.yaml
+++ b/examples/systemd-config.yaml
@@ -1,6 +1,5 @@
 targetConfigs:
-- name: fetchit
-  url: http://github.com/containers/fetchit
+- url: http://github.com/containers/fetchit
   systemd:
   - name: sysd-ex
     targetPath: examples/systemd

--- a/examples/systemd-enable-user.yaml
+++ b/examples/systemd-enable-user.yaml
@@ -1,6 +1,5 @@
 targetConfigs:
-- name: fetchit
-  url: https://github.com/containers/fetchit
+- url: https://github.com/containers/fetchit
   systemd:
   - name: httpd-user
     targetPath: examples/systemd

--- a/examples/systemd-enable.yaml
+++ b/examples/systemd-enable.yaml
@@ -1,6 +1,5 @@
 targetConfigs:
-- name: fetchit
-  url: http://github.com/containers/fetchit
+- url: http://github.com/containers/fetchit
   systemd:
   - name: httpd-root
     targetPath: examples/systemd

--- a/examples/systemd-restart.yaml
+++ b/examples/systemd-restart.yaml
@@ -1,6 +1,5 @@
 targetConfigs:
-- name: fetchit
-  url: http://github.com/containers/fetchit
+- url: http://github.com/containers/fetchit
   systemd:
   - name: sysd-ex
     targetPath: examples/systemd

--- a/pkg/engine/ansible.go
+++ b/pkg/engine/ansible.go
@@ -36,7 +36,7 @@ func (ans *Ansible) Process(ctx, conn context.Context, PAT string, skew int) {
 	if ans.initialRun {
 		err := getRepo(target, PAT)
 		if err != nil {
-			klog.Errorf("Failed to clone repo at %s for target %s: %v", target.url, target.name, err)
+			klog.Errorf("Failed to clone repository %s: %v", target.url, err)
 			return
 		}
 

--- a/pkg/engine/apply.go
+++ b/pkg/engine/apply.go
@@ -65,8 +65,7 @@ func getLatest(target *Target) (plumbing.Hash, error) {
 		return plumbing.Hash{}, utils.WrapErr(err, "Error getting reference to worktree for repository", target.name)
 	}
 
-	err = wt.Checkout(&git.CheckoutOptions{Hash: branch.Hash()})
-	if err != nil {
+	if err := wt.Checkout(&git.CheckoutOptions{Hash: branch.Hash()}); err != nil {
 		return plumbing.Hash{}, utils.WrapErr(err, "Error checking out %s on branch %s", branch.Hash(), target.branch)
 	}
 
@@ -83,9 +82,10 @@ func getCurrent(target *Target, methodType, methodName string) (plumbing.Hash, e
 	}
 
 	ref, err := repo.Tag(tagName)
-	if err == git.ErrTagNotFound {
-		return plumbing.Hash{}, nil
-	} else if err != nil {
+	if err != nil {
+		if err == git.ErrTagNotFound {
+			return plumbing.Hash{}, nil
+		}
 		return plumbing.Hash{}, utils.WrapErr(err, "Error getting reference to current tag")
 	}
 
@@ -106,8 +106,7 @@ func updateCurrent(ctx context.Context, target *Target, newCurrent plumbing.Hash
 		return utils.WrapErr(err, "Error deleting old current tag")
 	}
 
-	_, err = repo.CreateTag(tagName, newCurrent, nil)
-	if err != nil {
+	if _, err := repo.CreateTag(tagName, newCurrent, nil); err != nil {
 		return utils.WrapErr(err, "Error creating new current tag with hash %s", newCurrent)
 	}
 

--- a/pkg/engine/apply.go
+++ b/pkg/engine/apply.go
@@ -19,7 +19,7 @@ func applyChanges(ctx context.Context, target *Target, targetPath string, globPa
 	if desiredState.IsZero() {
 		return nil, errors.New("Cannot run Apply if desired state is empty")
 	}
-	directory := filepath.Base(target.name)
+	directory := filepath.Base(target.url)
 
 	currentTree, err := getSubTreeFromHash(directory, currentState, targetPath)
 	if err != nil {
@@ -41,10 +41,10 @@ func applyChanges(ctx context.Context, target *Target, targetPath string, globPa
 
 //getLatest will get the head of the branch in the repository specified by the target's url
 func getLatest(target *Target) (plumbing.Hash, error) {
-	directory := filepath.Base(target.name)
+	directory := filepath.Base(target.url)
 	repo, err := git.PlainOpen(directory)
 	if err != nil {
-		return plumbing.Hash{}, utils.WrapErr(err, "Error opening repository: %s", directory)
+		return plumbing.Hash{}, utils.WrapErr(err, "Error opening repository %s to fetch latest commit", directory)
 	}
 
 	refSpec := config.RefSpec(fmt.Sprintf("+refs/heads/%s:refs/heads/%s", target.branch, target.branch))
@@ -74,12 +74,12 @@ func getLatest(target *Target) (plumbing.Hash, error) {
 }
 
 func getCurrent(target *Target, methodType, methodName string) (plumbing.Hash, error) {
-	directory := filepath.Base(target.name)
+	directory := filepath.Base(target.url)
 	tagName := fmt.Sprintf("current-%s-%s", methodType, methodName)
 
 	repo, err := git.PlainOpen(directory)
 	if err != nil {
-		return plumbing.Hash{}, utils.WrapErr(err, "Error opening repository: %s", directory)
+		return plumbing.Hash{}, utils.WrapErr(err, "Error opening repository %s to fetch current commit", directory)
 	}
 
 	ref, err := repo.Tag(tagName)
@@ -93,12 +93,12 @@ func getCurrent(target *Target, methodType, methodName string) (plumbing.Hash, e
 }
 
 func updateCurrent(ctx context.Context, target *Target, newCurrent plumbing.Hash, methodType, methodName string) error {
-	directory := filepath.Base(target.name)
+	directory := filepath.Base(target.url)
 	tagName := fmt.Sprintf("current-%s-%s", methodType, methodName)
 
 	repo, err := git.PlainOpen(directory)
 	if err != nil {
-		return utils.WrapErr(err, "Error opening repository: %s", directory)
+		return utils.WrapErr(err, "Error opening repository %s to update current commit", directory)
 	}
 
 	err = repo.DeleteTag(tagName)
@@ -121,7 +121,7 @@ func getSubTreeFromHash(directory string, hash plumbing.Hash, targetPath string)
 
 	repo, err := git.PlainOpen(directory)
 	if err != nil {
-		return nil, utils.WrapErr(err, "Error opening repository: %s", directory)
+		return nil, utils.WrapErr(err, "Error opening repository %s to fetch sub tree from commit", directory)
 	}
 
 	commit, err := repo.CommitObject(hash)

--- a/pkg/engine/clean.go
+++ b/pkg/engine/clean.go
@@ -41,7 +41,7 @@ func (p *Prune) Process(ctx, conn context.Context, PAT string, skew int) {
 
 	err := p.prunePodman(ctx, conn, opts)
 	if err != nil {
-		klog.Warningf("Repo: %s Method: %s encountered error: %v, resetting...", target.name, pruneMethod, err)
+		klog.Warningf("Repository: %s Method: %s encountered error: %v, resetting...", target.url, pruneMethod, err)
 	}
 
 }

--- a/pkg/engine/disconnected.go
+++ b/pkg/engine/disconnected.go
@@ -16,11 +16,11 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func extractZip(url, name string) error {
-	cache := "/opt/.cache/" + name + "/"
-	dest := cache + "HEAD"
+func extractZip(url string) error {
 	trimDir := strings.TrimSuffix(url, path.Ext(url))
 	directory := filepath.Base(trimDir)
+	cache := "/opt/.cache/" + directory + "/"
+	dest := cache + "HEAD"
 	absPath, err := filepath.Abs(directory)
 
 	data, err := http.Get(url)
@@ -46,9 +46,9 @@ func extractZip(url, name string) error {
 			// Create the destination file
 			os.MkdirAll(directory, 0755)
 
-			outFile, err := os.Create(absPath + "/" + name + ".zip")
+			outFile, err := os.Create(absPath + "/" + directory + ".zip")
 			if err != nil {
-				klog.Error("Failed creating file ", absPath+"/"+name+".zip")
+				klog.Error("Failed creating file ", absPath+"/"+directory+".zip")
 				return err
 			}
 
@@ -95,7 +95,7 @@ func extractZip(url, name string) error {
 				klog.Error("Failed removing file ", outFile.Name())
 				return err
 			}
-			createDiffFile(name)
+			createDiffFile(directory)
 			return nil
 		} else {
 			klog.Info("No changes since last disonnected run...requeuing")

--- a/pkg/engine/fetchit.go
+++ b/pkg/engine/fetchit.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
-	"path"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/containers/podman/v4/pkg/bindings"
@@ -136,7 +134,6 @@ func (fc *FetchitConfig) populateFetchit(config *FetchitConfig) *Fetchit {
 			os.Setenv("FETCHIT_CONFIG_URL", config.ConfigReload.ConfigURL)
 			// Convert configReload to a proper target for processing
 			reload := &TargetConfig{
-				Name:         configFileMethod,
 				configReload: config.ConfigReload,
 			}
 			config.TargetConfigs = append(config.TargetConfigs, reload)
@@ -144,7 +141,6 @@ func (fc *FetchitConfig) populateFetchit(config *FetchitConfig) *Fetchit {
 	}
 	if config.Prune != nil {
 		prune := &TargetConfig{
-			Name:  pruneMethod,
 			prune: config.Prune,
 		}
 		config.TargetConfigs = append(config.TargetConfigs, prune)
@@ -152,7 +148,6 @@ func (fc *FetchitConfig) populateFetchit(config *FetchitConfig) *Fetchit {
 	if config.Images != nil {
 		for _, i := range config.Images {
 			imageLoad := &TargetConfig{
-				Name:  i.Name,
 				image: i,
 			}
 			config.TargetConfigs = append(config.TargetConfigs, imageLoad)
@@ -161,7 +156,6 @@ func (fc *FetchitConfig) populateFetchit(config *FetchitConfig) *Fetchit {
 	if config.PodmanAutoUpdate != nil {
 		sysds := config.PodmanAutoUpdate.AutoUpdateSystemd()
 		autoUp := &TargetConfig{
-			Name:    podmanAutoUpdate,
 			Systemd: sysds,
 		}
 		config.TargetConfigs = append(config.TargetConfigs, autoUp)
@@ -238,7 +232,6 @@ func getMethodTargetScheds(targetConfigs []*TargetConfig, fetchit *Fetchit) *Fet
 		tc.mu.Lock()
 		defer tc.mu.Unlock()
 		internalTarget := &Target{
-			name:         tc.Name,
 			url:          tc.Url,
 			device:       tc.Device,
 			branch:       tc.Branch,
@@ -317,7 +310,7 @@ func (f *Fetchit) RunTargets() {
 		// ConfigReload, PodmanAutoUpdateAll, Image, Prune methods do not include git URL
 		if method.GetTarget().url != "" {
 			if err := getRepo(method.GetTarget(), f.pat); err != nil {
-				klog.Warningf("Target: %s, clone error: %v, will retry next scheduled run", method.GetTarget().name, err)
+				klog.Warningf("Target: %s, clone error: %v, will retry next scheduled run", method.GetTarget(), err)
 			}
 		}
 	}
@@ -331,7 +324,7 @@ func (f *Fetchit) RunTargets() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		mt := method.GetKind()
-		klog.Infof("Processing Target: %s Method: %s Name: %s", method.GetTarget().name, mt, method.GetName())
+		klog.Infof("Processing git target: %s Method: %s Name: %s", method.GetTarget().url, mt, method.GetName())
 		s.Cron(schedInfo.schedule).Tag(mt).Do(method.Process, ctx, f.conn, f.pat, skew)
 		s.StartImmediately()
 	}
@@ -349,8 +342,7 @@ func getRepo(target *Target, PAT string) error {
 	return nil
 }
 func getClone(target *Target, PAT string) error {
-	trimDir := strings.TrimSuffix(target.url, path.Ext(target.url))
-	directory := filepath.Base(trimDir)
+	directory := getDirectory(target)
 	absPath, err := filepath.Abs(directory)
 	if err != nil {
 		return err
@@ -389,8 +381,7 @@ func getClone(target *Target, PAT string) error {
 }
 
 func getDisconnected(target *Target) error {
-	trimDir := strings.TrimSuffix(target.url, path.Ext(target.url))
-	directory := filepath.Base(trimDir)
+	directory := getDirectory(target)
 	var exists bool
 	if _, err := os.Stat(directory); err == nil {
 		exists = true
@@ -402,13 +393,13 @@ func getDisconnected(target *Target) error {
 		return err
 	}
 	if !exists {
-		extractZip(target.url, target.name)
+		extractZip(target.url)
 	}
 	return nil
 }
 
 func getDeviceDisconnected(target *Target) error {
-	directory := filepath.Base(target.url)
+	directory := getDirectory(target)
 	var exists bool
 	if _, err := os.Stat(directory); err == nil {
 		exists = true
@@ -420,7 +411,7 @@ func getDeviceDisconnected(target *Target) error {
 		return err
 	}
 	if !exists {
-		localDevicePull(target.name, target.device, "", false)
+		localDevicePull(directory, target.device, "", false)
 	}
 	return nil
 }

--- a/pkg/engine/fetchit.go
+++ b/pkg/engine/fetchit.go
@@ -408,7 +408,7 @@ func getDisconnected(target *Target) error {
 }
 
 func getDeviceDisconnected(target *Target) error {
-	directory := filepath.Base(target.name)
+	directory := filepath.Base(target.url)
 	var exists bool
 	if _, err := os.Stat(directory); err == nil {
 		exists = true

--- a/pkg/engine/filetransfer.go
+++ b/pkg/engine/filetransfer.go
@@ -33,10 +33,10 @@ func (ft *FileTransfer) Process(ctx, conn context.Context, PAT string, skew int)
 		err := getRepo(target, PAT)
 		if err != nil {
 			if len(target.url) > 0 {
-				klog.Errorf("Failed to clone repo at %s for target %s: %v", target.url, target.name, err)
+				klog.Errorf("Failed to clone repository at %s: %v", target.url, err)
 				return
 			} else if len(target.localPath) > 0 {
-				klog.Errorf("Failed to clone repo at %s for target %s: %v", target.localPath, target.name, err)
+				klog.Errorf("Failed to clone repository %s: %v", target.localPath, err)
 				return
 			}
 		}

--- a/pkg/engine/image.go
+++ b/pkg/engine/image.go
@@ -41,14 +41,14 @@ func (i *Image) Process(ctx, conn context.Context, PAT string, skew int) {
 	defer target.mu.Unlock()
 
 	if len(i.Url) > 0 {
-		err := i.loadHTTPPodman(ctx, conn, i.Url, target.name)
+		err := i.loadHTTPPodman(ctx, conn, i.Url)
 		if err != nil {
-			klog.Warningf("Repo: %s Method: %s encountered error: %v, resetting...", target.name, imageMethod, err)
+			klog.Warningf("Repository: %s Method: %s encountered error: %v, resetting...", target.url, imageMethod, err)
 		}
 	} else if len(i.ImagePath) > 0 {
 		err := i.loadDevicePodman(ctx, conn)
 		if err != nil {
-			klog.Warningf("Repo: %s Method: %s encountered error: %v, resetting...", target.name, imageMethod, err)
+			klog.Warningf("Repository: %s Method: %s encountered error: %v, resetting...", target.url, imageMethod, err)
 		}
 	}
 }
@@ -61,7 +61,7 @@ func (i *Image) Apply(ctx, conn context.Context, currentState, desiredState plum
 	return nil
 }
 
-func (i *Image) loadHTTPPodman(ctx, conn context.Context, url, target string) error {
+func (i *Image) loadHTTPPodman(ctx, conn context.Context, url string) error {
 	imageName := (path.Base(url))
 	pathToLoad := "/opt/" + imageName
 	data, err := http.Get(url)

--- a/pkg/engine/kube.go
+++ b/pkg/engine/kube.go
@@ -47,7 +47,7 @@ func (k *Kube) Process(ctx, conn context.Context, PAT string, skew int) {
 	if initial {
 		err := getRepo(target, PAT)
 		if err != nil {
-			klog.Errorf("Failed to clone repo at %s for target %s: %v", target.url, target.name, err)
+			klog.Errorf("Failed to clone repository %s: %v", target.url, err)
 			return
 		}
 

--- a/pkg/engine/raw.go
+++ b/pkg/engine/raw.go
@@ -90,7 +90,7 @@ func (r *Raw) Process(ctx context.Context, conn context.Context, PAT string, ske
 	if r.initialRun {
 		err := getRepo(target, PAT)
 		if err != nil {
-			klog.Errorf("Failed to clone repo at %s for target %s: %v", target.url, target.name, err)
+			klog.Errorf("Failed to clone repository %s: %v", target.url, err)
 			return
 		}
 

--- a/pkg/engine/systemd.go
+++ b/pkg/engine/systemd.go
@@ -110,7 +110,7 @@ func (sd *Systemd) Process(ctx, conn context.Context, PAT string, skew int) {
 		}
 		err := getRepo(target, PAT)
 		if err != nil {
-			klog.Errorf("Failed to clone repo at %s for target %s: %v", target.url, target.name, err)
+			klog.Errorf("Failed to clone repository %s: %v", target.url, err)
 			return
 		}
 

--- a/pkg/engine/types.go
+++ b/pkg/engine/types.go
@@ -49,7 +49,6 @@ type TargetConfig struct {
 }
 
 type Target struct {
-	name         string
 	url          string
 	device       string
 	localPath    string


### PR DESCRIPTION
This PR:
* fixes a bug with git.PlainOpen fns - they were opening `filepath.Base(target.name)`  instead of `filepath.Base(target.url)`  (in all of our workflow examples, we use url `github.com/containers/fetchit` and the targetConfig.Name `fetchit`, so it wasn't caught. The bug is only noticed if you set targetConfig.Name to anything else, like `example`). 
  * since we no longer need target.name (leftover from when we could only have 1 of each method per target) removed it here and updated to always `trim the path.Ext from target.url`
* improves error messages with git.PlainOpen, for better debugging

/cc @cooktheryan 
/cc @josephsawaya 

Signed-off-by: Sally O'Malley <somalley@redhat.com>