### PR TITLE
add caller to logger

### DIFF
--- a/pkg/engine/start.go
+++ b/pkg/engine/start.go
@@ -32,7 +32,7 @@ func InitLogger() {
 	syncer := zap.CombineWriteSyncers(os.Stdout, getLogWriter())
 	encoder := getEncoder()
 	core := zapcore.NewCore(encoder, syncer, zap.NewAtomicLevelAt(zap.InfoLevel))
-	l := zap.New(core)
+	l := zap.New(core, zap.AddCaller())
 	logger = l.Sugar()
 }
 


### PR DESCRIPTION
With logger, add the AddCaller() option to print filename/linenumber with logging, like so:

```
2022-09-19T15:07:00.102Z	INFO	engine/common.go:99	No changes applied to git target fetchit this run, filetransfer..
```