### PR TITLE
Update quick_start.rst

### DIFF
--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -27,7 +27,7 @@ Next, create a configuration file.
      - name: welcome-to-fetchit
        targetPath: examples/single-raw
        schedule: "*/1 * * * *"
-       pullImage: false
+       pullImage: true
      branch: main
 
 Finally, run FetchIt.


### PR DESCRIPTION
It's weird to have `false` for the pull image. If you are copy pastaing this to work; and when you start it, nothing happens until you read the config file again, can be frustrating.