### PR TITLE
[WIP] Add support for reading secret password and PAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ CONTAINER ID  IMAGE       COMMAND     CREATED     STATUS      PORTS       NAMES
 
 
 ### FetchIt launch options
-FetchIt and can be started manually or launched via systemd. 
+FetchIt can be started manually or launched via systemd.
 
 Define the parameters in your `$HOME/.fetchit/config.yaml` to relate to your git repository.
 This example can be found in [./examples/readme-config.yaml](examples/readme-config.yaml)
@@ -61,7 +61,7 @@ targetConfigs:
   - name: ft-ex
     targetPath: examples/fileTransfer
     destinationDirectory: /tmp
-    schedule: "*/1 * * * *" 
+    schedule: "*/1 * * * *"
   raw:
   - name: raw-ex
     targetPath: examples/raw

--- a/pkg/engine/gitauth.go
+++ b/pkg/engine/gitauth.go
@@ -9,11 +9,13 @@ var defaultSSHKey = filepath.Join("/opt", "mount", ".ssh", "id_rsa")
 
 // Basic type needed for ssh authentication
 type GitAuth struct {
-	SSH        bool   `mapstructure:"ssh"`
-	SSHKeyFile string `mapstructure:"sshKeyFile"`
-	Username   string `mapstructure:"username"`
-	Password   string `mapstructure:"password"`
-	PAT        string `mapstructure:"pat"`
+	SSH            bool   `mapstructure:"ssh"`
+	SSHKeyFile     string `mapstructure:"sshKeyFile"`
+	Username       string `mapstructure:"username"`
+	Password       string `mapstructure:"password"`
+	SecretPassword string `mapstructure:"secret_password"`
+	PAT            string `mapstructure:"pat"`
+	SecretPAT      string `mapstructure:"secret_pat"`
 }
 
 // Checks to see if private key exists on given path

--- a/pkg/engine/types.go
+++ b/pkg/engine/types.go
@@ -54,8 +54,10 @@ type Target struct {
 	sshKey          string
 	url             string
 	pat             string
+	secret_pat      string
 	username        string
 	password        string
+	secret_password string
 	device          string
 	localPath       string
 	branch          string


### PR DESCRIPTION
Fixes #272
Depends on https://github.com/containers/fetchit/pull/274

It's considered a fairly universally bad thing to commit credentials
into git.  Implement a more secure solution whereby FetchIt loads
password or PAT from an environment secret (i.e. a special env. var.).
They may be specified either in YAML, or in the environment via
`$FETCHIT_SECRET_PASSWORD` or `$FETCHIT_SECRET_PAT`.  In all cases,
the value indicates the name of an environment-secret to retrieve.  The
environment-secret contains the actual password or PAT to be used.