### PR TITLE
Add env. var. to enable debug logging

### DIFF
--- a/pkg/engine/start.go
+++ b/pkg/engine/start.go
@@ -31,9 +31,14 @@ func init() {
 func InitLogger() {
 	syncer := zap.CombineWriteSyncers(os.Stdout, getLogWriter())
 	encoder := getEncoder()
-	core := zapcore.NewCore(encoder, syncer, zap.NewAtomicLevelAt(zap.InfoLevel))
+	level := zap.InfoLevel
+	if os.Getenv("FETCHIT_DEBUG") != "" {
+		level = zap.DebugLevel
+	}
+	core := zapcore.NewCore(encoder, syncer, zap.NewAtomicLevelAt(level))
 	l := zap.New(core, zap.AddCaller())
 	logger = l.Sugar()
+	logger.Debug("Fetchit debug logging enabled.")
 }
 
 func getEncoder() zapcore.Encoder {


### PR DESCRIPTION
Small convenience update.  Simply set `-e FETCHIT_DEBUG=1` (or any value), and it will start logging debug-level messages.  Given the lack of unit-tests (I hear they're a PITA in golang) being able to switch this on/off will greatly assist developers debugging their own shenanigans.