### PR TITLE
Speed up repeated builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,11 @@ LABEL name=fetchit-build
 
 ENV GOPATH=/opt/app-root GOCACHE=/mnt/cache GO111MODULE=on
 
+RUN dnf -y install gpgme-devel device-mapper-devel
+
 WORKDIR $GOPATH/src/github.com/containers/fetchit
 
 COPY . .
-
-RUN dnf -y install gpgme-devel device-mapper-devel
 
 RUN GOPATH=/opt/app-root GOCACHE=/mnt/cache make $MAKE_TARGET
 


### PR DESCRIPTION
It's not infrequent that developers need to build over and over again while working on the code.  Make this a bit faster by caching the result of installing dependencies.  This way, repeatedly building won't perform the same package install over and over again.

Signed-off-by: Chris Evich <cevich@redhat.com>