### PR TITLE
apply owned-by=fetchit label to raw pods

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -437,6 +437,24 @@ jobs:
 
       - name: Check that no capabilities exist for cap2
         run: if [[ $(sudo podman container inspect cap2 --format {{.EffectiveCaps}} | jq length) = "0" ]] ; then echo "Container successfully launched"; else exit 1; fi
+      
+      - name: 'Check that the "owned-by:fetchit" label is applied' 
+        run: |
+          declare -i numContainers=$(sudo podman ps --filter label=owned-by=fetchit | wc -l)
+          if (( numContainers > 1 )); then
+            echo 'Successfully applied labels'
+          else
+            exit 1
+          fi
+
+          # check against a garbage label
+          declare -i checkAgainst=$(sudo podman ps --filter label=owned-by=abcdefghijklmnopqrstuvwxyz | wc -l)
+          if (( checkAgainst == numContainers )); then
+            echo 'container amount with label cannot equal container amount with nonexistent label'
+            exit 1
+          else
+            echo 'Label was applied correctly'
+          fi
 
   config-env-raw-validate:
     runs-on: ubuntu-latest

--- a/pkg/engine/raw.go
+++ b/pkg/engine/raw.go
@@ -17,7 +17,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const rawMethod = "raw"
+const (
+	rawMethod    = "raw"
+	FetchItLabel = "fetchit"
+)
 
 // Raw to deploy pods from json or yaml files
 type Raw struct {
@@ -241,6 +244,10 @@ func createSpecGen(raw RawPod) *specgen.SpecGenerator {
 	s.CapAdd = []string(raw.CapAdd)
 	s.CapDrop = []string(raw.CapDrop)
 	s.RestartPolicy = "always"
+	// add a label to signify ownership of fetchit <--> this container
+	s.Labels = map[string]string{
+		"owned-by": FetchItLabel,
+	}
 	return s
 }
 


### PR DESCRIPTION
This PR aims to help podman track which raw pods are owned by fetchit by applying a `owned-by=fetchit` to the raw pod spec when they are created.
Signed-off-by: Oleg <97077423+RobotSail@users.noreply.github.com>