### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ cp systemd/fetchit-root.service /etc/systemd/system/fetchit.service
 systemctl enable fetchit --now
 ```
 
-For user
+For $USER
 ```
 mkdir -p ~/.config/systemd/user/
 cp systemd/fetchit-user.service ~/.config/systemd/user/fetchit.service

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ targetConfigs:
 ```
 
 #### Launch using systemd
-Two systemd files are provided to allow for FetchIt to run as a user or as root. The files are differentiated by fetchit-root and fetchit-user.
+Two systemd files are provided to allow for FetchIt to run as a user or as root. The files are under the systemd folder, differentiated by fetchit-root and fetchit-user.
 
 Ensure that there is a config at `$HOME/.fetchit/config.yaml` before attempting to start the service.
 
@@ -79,6 +79,7 @@ cp systemd/fetchit-root.service /etc/systemd/system/fetchit.service
 systemctl enable fetchit --now
 ```
 
+For user
 ```
 mkdir -p ~/.config/systemd/user/
 cp systemd/fetchit-user.service ~/.config/systemd/user/fetchit.service


### PR DESCRIPTION
Add a missing separation between the root and user systemd config details
Point that the systemd examples are inside the "systemd" folder