### PR TITLE
fix systemd restart logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ To develop and test changes of FetchIt, the FetchIt image can be built locally a
 
 ```
 go mod tidy
+go mod vendor
 podman build . --file Dockerfile --tag quay.io/fetchit/fetchit-amd:latest
 podman tag quay.io/fetchit/fetchit-amd:latest quay.io/fetchit/fetchit:latest
 ```

--- a/go.mod
+++ b/go.mod
@@ -242,7 +242,7 @@ require (
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/term v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
-	golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9 // indirect
+	golang.org/x/time v0.1.0 // indirect
 	golang.org/x/tools v0.3.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect

--- a/go.sum
+++ b/go.sum
@@ -3526,7 +3526,6 @@ golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20220411224347-583f2d630306/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9 h1:ftMN5LMiBFjbzleLqtoBZk7KdJwhuybIU+FckUHgoyQ=
 golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20220922220347-f3bd1da661af/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.1.0 h1:xYY+Bajn2a7VBmTM5GikTmnK8ZuX8YgnQCqZpbBNtmA=

--- a/pkg/engine/systemd.go
+++ b/pkg/engine/systemd.go
@@ -215,6 +215,12 @@ func (sd *Systemd) systemdPodman(ctx context.Context, conn context.Context, path
 			return sd.enableRestartSystemdService(conn, "enable", dest, filepath.Base(*curr))
 		}
 	}
+	if *changeType == "rename" {
+		if err := sd.enableRestartSystemdService(conn, "stop", dest, filepath.Base(*prev)); err != nil {
+			return err
+		}
+		return sd.enableRestartSystemdService(conn, "enable", dest, filepath.Base(*curr))
+	}
 	if *changeType == "delete" {
 		return sd.enableRestartSystemdService(conn, "stop", dest, filepath.Base(*prev))
 	}


### PR DESCRIPTION
As mentioned on #328 I could not figure out how to make the systemd method work as I expected in production. After digging through the code I believe I have figured out how to fix it.

Please share thoughts and concerns on this change. I'm not a Go expert so anything is welcome.

A few notes on this change:
* I couldn't build without running "go mod tidy -go=1.16 && go mod tidy -go=1.17" which changed the go.mod & go.sum.
* Also I had to run "go mod vendor" and added that to the instructions in README.md
* ~~I did not try to tackle a service rename yet, I'm not even sure if it will be processed as a rename.~~
* I have not tried to figure out why the systemd-restart-validate test in .github/workflows/docker-image.yml did not catch this issue