### PR TITLE
Check for response code 200, if not 200 return error

### DIFF
--- a/pkg/engine/config.go
+++ b/pkg/engine/config.go
@@ -187,7 +187,7 @@ func downloadUpdateConfigFile(urlStr string, existsAlready, initial bool, pat, u
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return false, fmt.Errorf("received non-200 HTTP status: %d %s", resp.StatusCode, resp.Status)
+		return false, fmt.Errorf("received non-200 HTTP status from %s: %d %s", urlStr, resp.StatusCode, resp.Status)
 	}
 
 	newBytes, err := io.ReadAll(resp.Body)


### PR DESCRIPTION
I was trying to get fetchit working with a private gitlab repo and had to read the code to find out that it only seems to work with github?  Adding a simple check like this will help users identify if there is an issue with the http request.

I plan to send future PRs so that fetchit will work with gitlab as well.

Thanks!

## Summary by Sourcery

Add an HTTP status code check to downloadUpdateConfigFile to error on non-200 responses and improve error messaging with URL context.

Bug Fixes:
- Return an error when the HTTP response status is not 200 in downloadUpdateConfigFile.

Enhancements:
- Include the request URL in the error message when failing to read the response body.