### PR TITLE
Fix: Update go mod tidy compatibility from 1.21 to 1.25

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -994,8 +994,20 @@ jobs:
       - name: tag the image
         run: sudo podman tag quay.io/sallyom/httpd-ex:latest registry.access.redhat.com/ubi8/httpd-24:latest
 
+      - name: Debug - Check what curl returns
+        run: curl -v http://localhost:8080/ || true
+
+      - name: Debug - Check what curl returns for index.html
+        run: curl -v http://localhost:8080/index.html || true
+
+      - name: Debug - Exec into container to check httpd
+        run: sudo podman exec httpd ps aux || true
+
+      - name: Debug - Check if index.html exists in container
+        run: sudo podman exec httpd ls -la /var/www/html/ || true
+
       - name: Wait for podman auto-update
-        run: timeout 150 bash -c -- 'msg=0 ; until [ $msg -ge 1 ]; do msg=$( curl -s localhost:8080/index.html | grep "Welcome to your static httpd application" | wc -l ); done'
+        run: timeout 150 bash -c -- 'msg=0 ; until [ $msg -ge 1 ]; do msg=$( curl -s localhost:8080/index.html | grep "Welcome to your static httpd application" | wc -l ); sleep 2; done'
 
       - name: check the service
         if: always()

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -93,7 +93,7 @@ jobs:
         run: sudo apt install curl
 
       - name: Build the image
-        run: go mod tidy -compat=1.21 && go mod vendor && docker build . --file Dockerfile --tag quay.io/fetchit/fetchit-amd:latest
+        run: go mod tidy -compat=1.25 && go mod vendor && docker build . --file Dockerfile --tag quay.io/fetchit/fetchit-amd:latest
 
       - name: Export image
         run: docker save -o /tmp/fetchit.tar quay.io/fetchit/fetchit-amd:latest
@@ -110,7 +110,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build the image
-        run: go mod tidy -compat=1.21 && go mod vendor && make build-ansible-cross-build-linux-amd64
+        run: go mod tidy -compat=1.25 && go mod vendor && make build-ansible-cross-build-linux-amd64
 
       - name: docker list images
         run: docker images
@@ -140,7 +140,7 @@ jobs:
         run: sudo apt install podman build-essential qemu-user qemu-user-static
 
       - name: Build the image
-        run: go mod tidy -compat=1.21 && go mod vendor && CTR_CMD=podman make build-ansible-cross-build-linux-arm64
+        run: go mod tidy -compat=1.25 && go mod vendor && CTR_CMD=podman make build-ansible-cross-build-linux-arm64
 
       - name: Export image
         run: podman save -o /tmp/ansible-arm.tar quay.io/fetchit/fetchit-ansible-arm:latest
@@ -172,7 +172,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build the image
-        run: go mod tidy -compat=1.21 && go mod vendor && make build-systemd-cross-build-linux-amd64
+        run: go mod tidy -compat=1.25 && go mod vendor && make build-systemd-cross-build-linux-amd64
 
       - name: docker list images
         run: docker images
@@ -202,7 +202,7 @@ jobs:
         run: sudo apt install podman build-essential qemu-user qemu-user-static
 
       - name: Build the image
-        run: go mod tidy -compat=1.21 && go mod vendor && CTR_CMD=podman make build-systemd-cross-build-linux-arm64
+        run: go mod tidy -compat=1.25 && go mod vendor && CTR_CMD=podman make build-systemd-cross-build-linux-arm64
 
       - name: Export image
         run: podman save -o /tmp/systemd-arm.tar quay.io/fetchit/fetchit-systemd-arm:latest
@@ -1968,7 +1968,7 @@ jobs:
         run: sudo apt install podman build-essential qemu-user qemu-user-static
 
       - name: Build the arm image
-        run: go mod tidy -compat=1.21 && go mod vendor && CTR_CMD=podman make build-containerized-cross-build-linux-arm64
+        run: go mod tidy -compat=1.25 && go mod vendor && CTR_CMD=podman make build-containerized-cross-build-linux-arm64
 
       - name: Export image
         run: podman save -o /tmp/fetchit-arm.tar quay.io/fetchit/fetchit-arm:latest


### PR DESCRIPTION
The selinux v1.13.0 update requires Go 1.25 as it dropped support for Go 1.23 and below. This resolves the build failures in GitHub Actions.

## Summary by Sourcery

CI:
- Bump go mod tidy -compat flag from 1.21 to 1.25 in all GitHub Actions jobs that build Docker/Podman images to restore compatibility with updated Go dependencies.